### PR TITLE
Restructured about page

### DIFF
--- a/contributors.yaml
+++ b/contributors.yaml
@@ -6,9 +6,11 @@
 - name: Sanja Bonic
   github: sanjacodes
   website: https://debugged.it
+  core: true
 - name: Janos Bonic
   github: janosdebugs
   website: https://debugged.it
+  core: true
 - name: Richard Kovacs
   github: mhmxs
   twitter: mhmxs
@@ -16,11 +18,13 @@
 - name: Bence Santha
   github: bencurio
   twitter: ecrazor1911
+  core: true
 - name: Montgomery Edwards⁴⁴⁸
   github: x448
 - name: Nikos Tsipinakis
   github: tsipinakis
   website: https://nikos.dev
+  core: true
 - name: Duc Tran
   github: ductnn
   website: https://ductn.info

--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -2,22 +2,36 @@ title: About ContainerSSH
 
 <h1>About ContainerSSH</h1>
 
-## Who makes ContainerSSH? Why?
-
 ContainerSSH is a *fully open source community-driven project*. It is made with ❤️ by the following group of volunteers.
 
-<span class="contributors">{% for contributor in contributors() -%}
+## Core maintainers
+
+<span class="contributors">{% for contributor in contributors() -%}{%- if contributor.core %}
 <span class="contributor">
     <span class="contributor__image"><img src="{{contributor.avatar_url}}" alt="" /></span>
     <span class="contributor__name">{{contributor.name}}</span>
-    {%- if contributor.staff %}<span class="contributor__role">core maintainer</span>{%else%}<span class="contributor__role">&nbsp;</span>{% endif -%} 
     <span class="contributor__social_wrapper">
         <a class="contributor__social contributor__social--github" target="_blank" href="https://github.com/{{contributor.github}}" title="GitHub">:fontawesome-brands-github:</a>
         {%- if contributor.twitter %}<a class="contributor__social contributor__social--twitter" target="_blank" href="https://twitter.com/{{contributor.twitter}}" title="Twitter">:fontawesome-brands-twitter:</a>{% endif -%}
         {%- if contributor.website %}<a class="contributor__social contributor__social--website" target="_blank" href="{{contributor.website}}" title="Website">:fontawesome-solid-globe:</a>{% endif -%}
         {%- if contributor.linkedin %}<a class="contributor__social contributor__social--linkedin" target="_blank" href="https://linkedin.com/in/{{contributor.linkedin}}" title="LinkedIn">:fontawesome-brands-linkedin:</a>{% endif -%}
     </span>
-</span>{% endfor %}</span>
+</span>{% endif %}{% endfor %}</span>
+
+## Contributors
+
+<span class="contributors">{% for contributor in contributors() -%}{%- if not contributor.core %}
+<span class="contributor">
+    <span class="contributor__image"><img src="{{contributor.avatar_url}}" alt="" /></span>
+    <span class="contributor__name">{{contributor.name}}</span>
+    <span class="contributor__social_wrapper">
+        <a class="contributor__social contributor__social--github" target="_blank" href="https://github.com/{{contributor.github}}" title="GitHub">:fontawesome-brands-github:</a>
+        {%- if contributor.twitter %}<a class="contributor__social contributor__social--twitter" target="_blank" href="https://twitter.com/{{contributor.twitter}}" title="Twitter">:fontawesome-brands-twitter:</a>{% endif -%}
+        {%- if contributor.website %}<a class="contributor__social contributor__social--website" target="_blank" href="{{contributor.website}}" title="Website">:fontawesome-solid-globe:</a>{% endif -%}
+        {%- if contributor.linkedin %}<a class="contributor__social contributor__social--linkedin" target="_blank" href="https://linkedin.com/in/{{contributor.linkedin}}" title="LinkedIn">:fontawesome-brands-linkedin:</a>{% endif -%}
+    </span>
+</span>{% endif %}{% endfor %}</span>
+
 
 <small>Note: this list is opt-in for privacy reasons. If you wish to be listed on this page please <a href="https://github.com/ContainerSSH/containerssh.github.io/edit/main/contributors.yaml">add your name here</a>.</small>
 


### PR DESCRIPTION
## Changes introduced with this PR

This PR restructures the about page:

- Core maintainers and contributors separated
- People sorted by names instead of by the number of GitHub contributions

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/ContainerSSH/community/blob/main/CONTRIBUTING.md).