### PR TITLE
Missing namespace in host.key secret creation

### DIFF
--- a/docs/reference/installation.md
+++ b/docs/reference/installation.md
@@ -53,7 +53,7 @@
     We will then create a secret containing the host key:
     
     ```bash
-    openssl genrsa | kubectl create secret generic -n  containerssh-hostkey --from-file=host.key=/dev/stdin
+    openssl genrsa | kubectl create secret generic -n containerssh containerssh-hostkey --from-file=host.key=/dev/stdin
     ```
 
     Finally, we will deploy ContainerSSH. Please customize as needed, especially the ContainerSSH configuration.


### PR DESCRIPTION

Signed-off-by: Jean-Pascal Journet <jjournet@users.noreply.github.com>

## Changes introduced with this PR

the kubectl command line to create the host.key secret during installation didn't work, it is missing the namespace.
Added the namespace (tested, and works if following the context of the doc)


---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/ContainerSSH/community/blob/main/CONTRIBUTING.md).