### PR TITLE
Update installation.md

### DIFF
--- a/docs/reference/installation.md
+++ b/docs/reference/installation.md
@@ -154,7 +154,6 @@
           automountServiceAccountToken: true
           securityContext:
             runAsNonRoot: true
-            readOnlyRootFilesystem: true
           containers:
           - image: containerssh/containerssh:0.4.1
             imagePullPolicy: IfNotPresent
@@ -171,6 +170,8 @@
               name: config
               readOnly: true
               subPath: config.yaml
+            securityContext:
+              readOnlyRootFilesystem: true
           restartPolicy: Always
           serviceAccount: containerssh
           serviceAccountName: containerssh


### PR DESCRIPTION
moving `readOnlyRootFilesystem: true` to container section as it was not working at deployment spec level in Kubernetes 1.24.3

close #35 

Signed-off-by: Jean-Pascal Journet <jjournet@users.noreply.github.com>

## Changes introduced with this PR

Please explain your changes here.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/ContainerSSH/community/blob/main/CONTRIBUTING.md).