### PR TITLE
Fix ciphers typo for ssh config reference

### DIFF
--- a/docs/reference/0.4.0/ssh.md
+++ b/docs/reference/0.4.0/ssh.md
@@ -15,7 +15,7 @@ The options are as follows:
 |------|------|-------------|
 | `listen` | `string` | IP and port pair to bind the SSH service to. Defaults to `0.0.0.0:2222` |
 | `serverVersion` | `string` | Server version string presented to any connecting client. Must start with `SSH-2.0-`. Defaults to `SSH-2.0-ContainerSSH`. |
-| `cipher` | `[]string` | List of ciphers the server should support. See the [Ciphers](#ciphers) section below. |
+| `ciphers` | `[]string` | List of ciphers the server should support. See the [Ciphers](#ciphers) section below. |
 | `kex` | `[]string` | List of key exchange algorithms the server should support. See the [Key exchange](#key-exchange) section below. |
 | `macs` | `[]string` | List of MAC algorithms the server should support. See the [MAC](#mac) section below. | 
 | `banner` | `[]string` | The banner text to presented to any connecting client. |

--- a/docs/reference/ssh.md
+++ b/docs/reference/ssh.md
@@ -14,7 +14,7 @@ The options are as follows:
 |------|------|-------------|
 | `listen` | `string` | IP and port pair to bind the SSH service to. Defaults to `0.0.0.0:2222` |
 | `serverVersion` | `string` | Server version string presented to any connecting client. Must start with `SSH-2.0-`. Defaults to `SSH-2.0-ContainerSSH`. |
-| `cipher` | `[]string` | List of ciphers the server should support. See the [Ciphers](#ciphers) section below. |
+| `ciphers` | `[]string` | List of ciphers the server should support. See the [Ciphers](#ciphers) section below. |
 | `kex` | `[]string` | List of key exchange algorithms the server should support. See the [Key exchange](#key-exchange) section below. |
 | `macs` | `[]string` | List of MAC algorithms the server should support. See the [MAC](#mac) section below. | 
 | `banner` | `[]string` | The banner text to presented to any connecting client. |

--- a/docs/reference/upcoming/ssh.md
+++ b/docs/reference/upcoming/ssh.md
@@ -16,7 +16,7 @@ The options are as follows:
 |------|------|-------------|
 | `listen` | `string` | IP and port pair to bind the SSH service to. Defaults to `0.0.0.0:2222` |
 | `serverVersion` | `string` | Server version string presented to any connecting client. Must start with `SSH-2.0-`. Defaults to `SSH-2.0-ContainerSSH`. |
-| `cipher` | `[]string` | List of ciphers the server should support. See the [Ciphers](#ciphers) section below. |
+| `ciphers` | `[]string` | List of ciphers the server should support. See the [Ciphers](#ciphers) section below. |
 | `kex` | `[]string` | List of key exchange algorithms the server should support. See the [Key exchange](#key-exchange) section below. |
 | `macs` | `[]string` | List of MAC algorithms the server should support. See the [MAC](#mac) section below. | 
 | `banner` | `[]string` | The banner text to presented to any connecting client. |


### PR DESCRIPTION
## Changes introduced with this PR

Seems there is a typo in ssh config reference manual.

It should be `ciphers` instead of `cipher`.
- relevant source code:
   - `0.5`: https://github.com/ContainerSSH/libcontainerssh/blob/main/config/ssh.go#L29
   - `0.4`: https://github.com/ContainerSSH/sshserver/blob/main/Config.go#L29

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/ContainerSSH/community/blob/main/CONTRIBUTING.md).