### PR TITLE
Version website with Mike

### DIFF
--- a/.docs-theme/main.html
+++ b/.docs-theme/main.html
@@ -46,3 +46,9 @@
         <div class="mdx-hero-separator"></div>
     </section>
 {% endblock %}
+{% block outdated %}
+  You're not viewing the latest version.
+  <a href="{{ '../' ~ base_url }}">
+    <strong>Click here to go to latest.</strong>
+  </a>
+{% endblock %}

--- a/.docs-theme/main.html
+++ b/.docs-theme/main.html
@@ -35,7 +35,7 @@
   <meta name="google-site-verification" content="VN4-Orfu-TOf9hXInR_ZdaZXQJDiak-dmPuaBc9TlwE" />
 {% endblock %}
 {% block announce %}
-  <a href="/blog/2021/05/26/containerssh-0-4-1/">
+  <a href="/latest/blog/2021/05/26/containerssh-0-4-1">
       ContainerSSH 0.4.1: Bugfixing Audit &amp; Proxy <strong>is now available</strong>! Read more &raquo;
   </a>
 {% endblock %}

--- a/.docs-theme/overrides/home.html
+++ b/.docs-theme/overrides/home.html
@@ -20,7 +20,7 @@
             </p>
         </div>
         <div class="mdx-hero__image">
-            <img src="/images/hero-header.svg" alt="" height="627" width="860" draggable="false">
+            <img src="images/hero-header.svg" alt="" height="627" width="860" draggable="false">
         </div>
     </div>
 </div>

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,8 +6,6 @@ on:
   pull_request:
     branches-ignore:
       - 'gh-pages'
-  schedule:
-    - cron: '0 * * * *'
 jobs:
   build:
     name: Build
@@ -24,44 +22,18 @@ jobs:
           architecture: x64
       - name: Install requirements.txt
         run: pip install -r requirements.txt
-      - name: Build
-        run: mkdocs build
+      - name: Setup git
+        run: |
+          git config --global user.name "$(git --no-pager log --format=format:'%an' -n 1)"
+          git config --global user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
+          git fetch origin gh-pages
+      - name: Deploy upcoming
+        run: mike deploy upcoming --push
+        if: github.ref == 'refs/heads/main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: site
-          path: site/*
-          if-no-files-found: error
-  deploy:
-    name: Deploy
-    runs-on: ubuntu-latest
-    needs:
-      - build
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          ref: gh-pages
-          path: dist
-      - name: Download artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: site
-          path: artifacts
-      - name: Deploy
-        run: |
-          set -euo pipefail
-          rsync -az --exclude=.git --delete ./artifacts/ ./dist/
-          cd dist
-          git config user.name "ContainerSSH Build Agent"
-          git config user.email 86986082+containersshbuilder@users.noreply.github.com
-          git add .
-          if ! git diff-index --quiet HEAD --; then
-            git commit -m "Website publish"
-            git push --set-upstream --force origin gh-pages
-          fi
+      - name: Deploy version
+        run: mike deploy "$GITHUB_REF_NAME" --push
+        if: startsWith(github.ref, 'refs/heads/v')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -228,8 +228,6 @@ nav:
 plugins:
   - search
   - macros
-  - blog:
-      format: ""
   - redirects:
       redirect_maps:
         'security.md': 'about/security.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,8 @@ theme:
   include_search_page: false
   search_index_only: 'false'
 extra:
+  version:
+    provider: mike
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/ContainerSSH
@@ -278,6 +280,6 @@ copyright: >
   | <a href="https://github.com/ContainerSSH/branding/blob/main/README.md">Brand assets</a>
   | <a href="/about/privacy/">Privacy Policy</a>
   | <a href="/about/imprint/">Imprint</a><br /><br />
-  <img src="/images/logos/cncf-white.svg" alt="Cloud Native Computing Foundation" /><br />
+  <img src="images/logos/cncf-white.svg" alt="Cloud Native Computing Foundation" /><br />
   We are a Cloud Native Computing Foundation sandbox project.<br /><br />
   The Linux Foundation® (TLF) has registered trademarks and uses trademarks. For a list of TLF trademarks, see <a href="https://www.linuxfoundation.org/trademark-usage/">Trademark Usage</a>. <a href="https://www.docker.com/legal/trademark-guidelines">Docker and the Docker logo are trademarks of Docker, Inc.</a>

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ PyGithub~=1.54
 pyyaml>=5.3.1
 requests
 mkdocs-rss-plugin
+mike


### PR DESCRIPTION
## Changes introduced with this PR

Introduce full website versioning with [`mike`](https://github.com/jimporter/mike) as recommended by [mkdocs docs](https://squidfunk.github.io/mkdocs-material/setup/setting-up-versioning/). While we do copy old version reference docs in the reference guide mike gives some distinct advantages, namely:
1. We can version all aspects of the site including getting started, installation guides etc
2. We do not have to rebuild, curate or make sure the old documentation is buildable/looks good with new mkdocs versions, mike does not rebuild old versions of the docs and simply lets them sit in the gh-pages branch.

This commit also updates the github actions workflow to automatically push the main branch to the `upcoming` version and any `v*` branches to the respective versions.

I'll merge in a weeks time unless someone stops me for a review.

![2023-09-03T20-17-40](https://github.com/ContainerSSH/containerssh.github.io/assets/18189112/777cf6a2-d53b-462b-851b-914bb0ca85d0)
![2023-09-03T20-17-51](https://github.com/ContainerSSH/containerssh.github.io/assets/18189112/c46dd5af-f07a-4fa0-b518-e81dbc6dd7e6)


---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/ContainerSSH/community/blob/main/CONTRIBUTING.md).