### PR TITLE
Remove deprecated `publicKey` field description

### DIFF
--- a/docs/getting-started/authserver.md
+++ b/docs/getting-started/authserver.md
@@ -36,7 +36,7 @@ The public key auth ContainerSSH will call out to `/pubkey` in the following for
 }
 ```
 
-The public key is provided in the SSH wire format in base64 encoding.
+The public key is provided in the SSH authorized key format.
 
 Your server will need to respond with the following JSON:
 


### PR DESCRIPTION
## Changes introduced with this PR

The "getting started" description of authentication server implementation still says the public key will show up base64-encoded and in wire format, but [it looks like that was deprecated](https://containerssh.io/v0.5/deprecations/publicKeyBase64/).

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/ContainerSSH/community/blob/main/CONTRIBUTING.md).