### PR TITLE
Fix the container image tags for v0.5

### DIFF
--- a/docs/downloads/index.md
+++ b/docs/downloads/index.md
@@ -9,11 +9,11 @@
     ContainerSSH can be installed in a containerized system (Kubernetes, Docker, Podman) by referencing the following image names:
     
     ```
-    containerssh/containerssh:0.5
-    containerssh/containerssh:0.5.1
+    containerssh/containerssh:v0.5
+    containerssh/containerssh:v0.5.1
 
-    quay.io/containerssh/containerssh:0.5
-    quay.io/containerssh/containerssh:0.5.1
+    quay.io/containerssh/containerssh:v0.5
+    quay.io/containerssh/containerssh:v0.5.1
     ```
     
     Our container images are built on **Alpine Linux (x86, 64 bit)**.


### PR DESCRIPTION
## Changes introduced with this PR

The container image tags for the last release were off. Previous releases had `0.x` format, but starting from v0.5 it changed to `v0.x`.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/ContainerSSH/community/blob/main/CONTRIBUTING.md).