### PR TITLE
Fixing backend name in example

### DIFF
--- a/docs/development/getting-started.md
+++ b/docs/development/getting-started.md
@@ -42,7 +42,7 @@ log:
 ssh:
   hostkeys:
     - ssh_host_rsa_key
-backend: dockerrun
+backend: docker
 auth:
   url: "http://127.0.0.1:8080"
   pubkey: false


### PR DESCRIPTION
## Changes introduced with this PR

This page in the docs references to the backend `dockerrun`, which doesn't exist anymore. This change should be also backported to older versions.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/ContainerSSH/community/blob/main/CONTRIBUTING.md).