### PR TITLE
docs: Add SFTP configuration examples for Kubernetes and Docker backends

### DIFF
--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -194,6 +194,42 @@ Apart from the `container`, `host`, `network`, `platform` and `containerName` op
 | `subsystems` | `map[string]string` | Specifies a map of subsystem names to executables. It is recommended to set at least the `sftp` subsystem as many users will want to use it. |
 | `imagePullPolicy` | `Never,IfNotPresent,Always` | Specifies when to pull the container image. Defaults to `IfNotPresent`, which pulls the image only when it is not locally present. It is recommended that you provide a custom, versioned image name to prevent pulling the image at every connection. |
 
+### Configuring SFTP
+
+ContainerSSH supports the SFTP subsystem for file transfer. To enable SFTP with the Docker backend, you need to configure the `subsystems` option in the execution configuration and ensure the SFTP server binary is available in the guest container image.
+
+The `subsystems` option is a map of subsystem names to their executable paths. The default configuration includes SFTP:
+
+```yaml
+docker:
+  execution:
+    subsystems:
+      sftp: /usr/lib/openssh/sftp-server
+```
+
+The default guest image (`containerssh/containerssh-guest-image`) includes the OpenSSH SFTP server at `/usr/lib/openssh/sftp-server`. If you're using a custom image, make sure to install the SFTP server (typically part of the `openssh-server` package on Linux) and adjust the path if necessary.
+
+For example, to enable SFTP with a custom image that has the SFTP server at a different location:
+
+```yaml
+docker:
+  execution:
+    container:
+      image: my-custom-image:latest
+    subsystems:
+      sftp: /usr/libexec/openssh/sftp-server  # Different path on some distributions
+```
+
+!!! note "SFTP binary must be present"
+    The SFTP subsystem will only work if the executable specified in the `subsystems` map exists inside the container. If the binary is missing, SFTP connections will fail with an error.
+
+!!! tip "Testing SFTP"
+    Once configured, you can test SFTP access with:
+    ```bash
+    sftp -P 2222 user@containerssh-host
+    ```
+    Replace `2222` with your ContainerSSH SSH port and `containerssh-host` with your ContainerSSH server address.
+
 ## Configuring timeouts
 
 The `timeouts` section has the following options. All options can use time units (e.g. `60s`) and default to nanoseconds without time units.

--- a/docs/reference/kubernetes.md
+++ b/docs/reference/kubernetes.md
@@ -213,6 +213,44 @@ Apart from the `metadata` and `spec` options ContainerSSH has the following opti
 - In `session` mode the restart policy must be empty or `Never`.
 - In `persistent` mode with `createMissingPods` enabled, the `idleCommand`, `shellCommand`, and at least one container in the pod spec are required.
 
+### Configuring SFTP
+
+ContainerSSH supports the SFTP subsystem for file transfer. To enable SFTP, you need to configure the `subsystems` option in the pod configuration and ensure the SFTP server binary is available in the guest container image.
+
+The `subsystems` option is a map of subsystem names to their executable paths. The default configuration includes SFTP:
+
+```yaml
+kubernetes:
+  pod:
+    subsystems:
+      sftp: /usr/lib/openssh/sftp-server
+```
+
+The default guest image (`containerssh/containerssh-guest-image`) includes the OpenSSH SFTP server at `/usr/lib/openssh/sftp-server`. If you're using a custom image, make sure to install the SFTP server (typically part of the `openssh-server` package on Linux) and adjust the path if necessary.
+
+For example, to enable SFTP with a custom image that has the SFTP server at a different location:
+
+```yaml
+kubernetes:
+  pod:
+    spec:
+      containers:
+        - name: shell
+          image: my-custom-image:latest
+    subsystems:
+      sftp: /usr/libexec/openssh/sftp-server  # Different path on some distributions
+```
+
+!!! note "SFTP binary must be present"
+    The SFTP subsystem will only work if the executable specified in the `subsystems` map exists inside the container. If the binary is missing, SFTP connections will fail with an error.
+
+!!! tip "Testing SFTP"
+    Once configured, you can test SFTP access with:
+    ```bash
+    sftp -P 2222 user@containerssh-host
+    ```
+    Replace `2222` with your ContainerSSH SSH port and `containerssh-host` with your ContainerSSH server address.
+
 ### Persistent mode
 
 The `persistent` execution mode allows ContainerSSH to exec into an already running pod rather than creating a new one for each connection or session. This is useful when you have long-lived pods that should be reused across SSH sessions, this can be used for example, to allow users to execute long-running procesess without the risk that it'll be terminated.


### PR DESCRIPTION
Addresses issue #589 which requested SFTP configuration examples.

Adds documentation showing how to configure the SFTP subsystem for both Kubernetes and Docker backends, including:
- Default SFTP server path in the guest image
- How to configure SFTP with custom images that may have the SFTP server at different paths
- Note about the SFTP binary needing to be present in the container
- Testing instructions with sftp command

The default guest image () includes the OpenSSH SFTP server at . Custom images need to have the SFTP server installed and the path configured accordingly.